### PR TITLE
Stop exporting development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,18 +2,12 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.editorconfig      export-ignore
 /.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/phpunit.xml.dist   export-ignore
 /art                export-ignore
-/docs               export-ignore
+/composer.lock      export-ignore
+/phpunit.xml        export-ignore
+/pint.json          export-ignore
 /tests              export-ignore
-/.editorconfig      export-ignore
-/.php_cs.dist.php   export-ignore
-/psalm.xml          export-ignore
-/psalm.xml.dist     export-ignore
-/testbench.yaml     export-ignore
-/UPGRADING.md       export-ignore
-/phpstan.neon.dist  export-ignore
-/phpstan-baseline.neon  export-ignore


### PR DESCRIPTION
Can be tested with `git archive HEAD | tar --list --exclude="src" --exclude="src/*"`