### PR TITLE
Add base rules

### DIFF
--- a/src/Rules/BaseRule.php
+++ b/src/Rules/BaseRule.php
@@ -14,6 +14,8 @@ class BaseRule
 
     public static string $rootPath = 'app/';
 
+    public static string $reason = 'we use Laravel framework!';
+
     public static function classSet(): ClassSet
     {
         return ClassSet::fromDir(static::directory());

--- a/src/Rules/Extending/BaseExtending.php
+++ b/src/Rules/Extending/BaseExtending.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mortexa\LaravelArkitect\Rules\Extending;
+
+use Arkitect\Expression\ForClasses\Extend;
+use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
+use Arkitect\Rules\DSL\ArchRule;
+use Arkitect\Rules\Rule;
+use Mortexa\LaravelArkitect\Contracts\RuleContract;
+use Mortexa\LaravelArkitect\Rules\BaseRule;
+
+abstract class BaseExtending extends BaseRule implements RuleContract
+{
+    public static string $namespace = 'Console\Commands';
+
+    public static string $path = 'Console/Commands';
+
+    public static array $except = [];
+
+    public static array $classNames = [];
+
+    public static function rule(): ArchRule
+    {
+        return Rule::allClasses()
+            ->except(...static::$except)
+            ->that(new ResideInOneOfTheseNamespaces(static::namespace()))
+            ->should(new Extend(...static::$classNames))
+            ->because(static::$reason);
+    }
+}

--- a/src/Rules/Extending/CommandsExtending.php
+++ b/src/Rules/Extending/CommandsExtending.php
@@ -4,24 +4,11 @@ declare(strict_types=1);
 
 namespace Mortexa\LaravelArkitect\Rules\Extending;
 
-use Arkitect\Expression\ForClasses\Extend;
-use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
-use Arkitect\Rules\DSL\ArchRule;
-use Arkitect\Rules\Rule;
-use Mortexa\LaravelArkitect\Contracts\RuleContract;
-use Mortexa\LaravelArkitect\Rules\BaseRule;
-
-class CommandsExtending extends BaseRule implements RuleContract
+class CommandsExtending extends BaseExtending
 {
     public static string $namespace = 'Console\Commands';
 
     public static string $path = 'Console/Commands';
 
-    public static function rule(): ArchRule
-    {
-        return Rule::allClasses()
-            ->that(new ResideInOneOfTheseNamespaces(static::namespace()))
-            ->should(new Extend('Illuminate\Console\Command'))
-            ->because('we use Laravel framework!');
-    }
+    public static array $classNames = ['Illuminate\Console\Command'];
 }

--- a/src/Rules/Extending/ControllersExtending.php
+++ b/src/Rules/Extending/ControllersExtending.php
@@ -4,25 +4,13 @@ declare(strict_types=1);
 
 namespace Mortexa\LaravelArkitect\Rules\Extending;
 
-use Arkitect\Expression\ForClasses\Extend;
-use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
-use Arkitect\Rules\DSL\ArchRule;
-use Arkitect\Rules\Rule;
-use Mortexa\LaravelArkitect\Contracts\RuleContract;
-use Mortexa\LaravelArkitect\Rules\BaseRule;
-
-class ControllersExtending extends BaseRule implements RuleContract
+class ControllersExtending extends BaseExtending
 {
     public static string $namespace = 'Http\Controllers';
 
     public static string $path = 'Http/Controllers';
 
-    public static function rule(): ArchRule
-    {
-        return Rule::allClasses()
-            ->except('App\Http\Controllers\Controller')
-            ->that(new ResideInOneOfTheseNamespaces(static::namespace()))
-            ->should(new Extend('App\Http\Controllers\Controller'))
-            ->because('we use Laravel framework!');
-    }
+    public static array $except = ['App\Http\Controllers\Controller'];
+
+    public static array $classNames = ['App\Http\Controllers\Controller'];
 }

--- a/src/Rules/Extending/ExceptionsExtending.php
+++ b/src/Rules/Extending/ExceptionsExtending.php
@@ -4,25 +4,13 @@ declare(strict_types=1);
 
 namespace Mortexa\LaravelArkitect\Rules\Extending;
 
-use Arkitect\Expression\ForClasses\Extend;
-use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
-use Arkitect\Rules\DSL\ArchRule;
-use Arkitect\Rules\Rule;
-use Mortexa\LaravelArkitect\Contracts\RuleContract;
-use Mortexa\LaravelArkitect\Rules\BaseRule;
-
-class ExceptionsExtending extends BaseRule implements RuleContract
+class ExceptionsExtending extends BaseExtending
 {
     public static string $namespace = 'Exceptions';
 
     public static string $path = 'Exceptions';
 
-    public static function rule(): ArchRule
-    {
-        return Rule::allClasses()
-            ->except('App\Exceptions\Handler')
-            ->that(new ResideInOneOfTheseNamespaces(static::namespace()))
-            ->should(new Extend('Exception'))
-            ->because('we use Laravel framework!');
-    }
+    public static array $except = ['App\Exceptions\Handler'];
+
+    public static array $classNames = ['Exception'];
 }

--- a/src/Rules/Extending/FactoriesExtending.php
+++ b/src/Rules/Extending/FactoriesExtending.php
@@ -4,26 +4,13 @@ declare(strict_types=1);
 
 namespace Mortexa\LaravelArkitect\Rules\Extending;
 
-use Arkitect\Expression\ForClasses\Extend;
-use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
-use Arkitect\Rules\DSL\ArchRule;
-use Arkitect\Rules\Rule;
-use Mortexa\LaravelArkitect\Contracts\RuleContract;
-use Mortexa\LaravelArkitect\Rules\BaseRule;
-
-class FactoriesExtending extends BaseRule implements RuleContract
+class FactoriesExtending extends BaseExtending
 {
     public static string $namespace = 'Database\Factories';
 
     public static string $path = 'database/factories';
 
-    public static function rule(): ArchRule
-    {
-        return Rule::allClasses()
-            ->that(new ResideInOneOfTheseNamespaces(static::namespace()))
-            ->should(new Extend('Illuminate\Database\Eloquent\Factories\Factory'))
-            ->because('we use Laravel framework!');
-    }
+    public static array $classNames = ['Illuminate\Database\Eloquent\Factories\Factory'];
 
     public static function namespace(): string
     {

--- a/src/Rules/Extending/ModelsExtending.php
+++ b/src/Rules/Extending/ModelsExtending.php
@@ -4,30 +4,18 @@ declare(strict_types=1);
 
 namespace Mortexa\LaravelArkitect\Rules\Extending;
 
-use Arkitect\Expression\ForClasses\Extend;
-use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
-use Arkitect\Rules\DSL\ArchRule;
-use Arkitect\Rules\Rule;
-use Mortexa\LaravelArkitect\Contracts\RuleContract;
-use Mortexa\LaravelArkitect\Rules\BaseRule;
-
-class ModelsExtending extends BaseRule implements RuleContract
+class ModelsExtending extends BaseExtending
 {
     public static string $namespace = 'Models';
 
     public static string $path = 'Models';
 
-    public static function rule(): ArchRule
-    {
-        return Rule::allClasses()
-            ->except(
-                'App\Models\User',
-                'App\Models\Admin',
-                'App\Models\Client',
-                'App\Models\Scopes'
-            )
-            ->that(new ResideInOneOfTheseNamespaces(static::namespace()))
-            ->should(new Extend('Illuminate\Database\Eloquent\Model'))
-            ->because('we use Laravel framework!');
-    }
+    public static array $except = [
+        'App\Models\User',
+        'App\Models\Admin',
+        'App\Models\Client',
+        'App\Models\Scopes',
+    ];
+
+    public static array $classNames = ['Illuminate\Database\Eloquent\Model'];
 }


### PR DESCRIPTION
Hey @smortexa 

Just wanted to say thanks for the great package! I've just implemented this on a work project and it's great to have all the default Laravel rules as a starting point.

Due to the sheer size of our project, however, we had a lot of failures, mainly due to our own internal abstractions and namespaces/legacy files that just need ignoring. To work around this, I've added several abstract 'base rules' that allow us to easily extend some defaults. I wanted to propose something like this for the base package as it would make extending and customising the provided rules much easier as well as being really easy to add new custom rules.

I'm opening this draft PR as an example and to gauge your interest, but would be happy to implement for the remainder of the rules. I don't think this would be a breaking change (but I may have naively overlooked something) and I think this would be a neat addition to the package, especially when adding to larger projects. Would be great to hear your thoughts?

Thanks again!         